### PR TITLE
dump_annotations doesn't print when verbose is disabled

### DIFF
--- a/client/cytomine/cytomine.py
+++ b/client/cytomine/cytomine.py
@@ -908,9 +908,11 @@ class Cytomine(object):
                                                 
                     else:   
                         #use original cropURL (smallest bounding box around the annotation)
-                        print "Get crop at zoom %d" %desired_zoom
+                        if self.__verbose:
+                            print "Get crop at zoom %d" %desired_zoom
                         cropURL = get_image_url_func(annot, desired_zoom, desired_max_size)
-                        print "cropURL: %s" %cropURL
+                        if self.__verbose:
+                            print "cropURL: %s" %cropURL
                         queue.put((cropURL, filename, annot))
 
         queue.join()


### PR DESCRIPTION
Don't print crop info when not in verbose mode in dump_annotations