### PR TITLE
Remove transitive dependency 'six' from 'setup.py' and 'requirements.txt'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,6 @@ requests-toolbelt==0.9.1
     # via cytomine-python-client (setup.py)
 shapely==1.7.1
     # via cytomine-python-client (setup.py)
-six==1.16.0
-    # via cytomine-python-client (setup.py)
 urllib3==1.26.19
     # via
     #   cytomine-python-client (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "requests-toolbelt>=0.8.0",
         "CacheControl>=0.12.10",
         "Shapely>=1.6.4",
-        "six>=1.11.0",
         "requests>=2.27.1",
         "urllib3>=1.25.2",
     ],


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `six` is specified as an install requirement in the `setup.py` and `requirements.txt` files, even though it is not used directly and does not need to be listed explicitly.

This PR removes it from `setup.py` and `requirements.txt` to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!